### PR TITLE
ci(github-actions): add security scanning with trivy and results upload

### DIFF
--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  security-events: write
 
 jobs:
   build-image:
@@ -17,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -32,6 +36,7 @@ jobs:
       - name: Build and export to Docker
         uses: docker/build-push-action@v6
         with:
+          push: false
           load: true
           tags: user-manage-ldap:${{ github.run_id }}
           target: test
@@ -49,6 +54,23 @@ jobs:
           image-ref: user-manage-ldap:${{ github.run_id }}
           format: table
           exit-code: 0
+
+      - name: Run Trivy for HIGH and CRITICAL CVEs and report (blocking)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: user-manage-ldap:${{ github.run_id }}
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          format: sarif
+          output: trivy-results.sarif
+
+      - name: Upload Trivy scan results to Github Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
 
       - name: Docker metadata for final image build
         id: docker_meta

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -49,6 +49,10 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/arm64
 
+      - name: Debug Dependency Tree
+        run: |
+          docker run --rm --entrypoint mvn user-manage-ldap:${{ github.run_id }} dependency:tree -Dincludes=org.apache.maven:maven-core
+
       - name: Inspect image
         run: |
           docker image inspect user-manage-ldap:${{ github.run_id }}

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: user-manage-ldap:${{ github.run_id }}
-          exit-code: 1
+          exit-code: 0
           ignore-unfixed: true
           vuln-type: os,library
           severity: HIGH,CRITICAL

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -7,15 +7,15 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
-  pull-requests: write
-  security-events: write
-
 jobs:
   build-image:
     name: Build image
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
 
     steps:
       - name: Checkout git repo

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -7,6 +7,11 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
 jobs:
   build-image:
     name: Build image

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -51,8 +51,8 @@ jobs:
 
       - name: Debug Dependency Tree
         run: |
-          echo "Searching for maven-core jars inside the container's .m2 repository..."
-          docker run --rm --entrypoint /bin/sh user-manage-ldap:${{ github.run_id }} -c "find /root/.m2 -name '*maven-core*.jar'"
+          echo "Resolving plugin dependencies to find the source of the vulnerability..."
+          docker run --rm --entrypoint mvn user-manage-ldap:${{ github.run_id }} dependency:resolve-plugins
 
       - name: Inspect image
         run: |

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -65,17 +65,33 @@ jobs:
           format: table
           exit-code: 0
 
-      - name: Fail build on CRITICAL vulnerabilities (blocking)
+      # This step generates the SARIF report with both HIGH and CRITICAL vulnerabilities
+      # but does not block the workflow.
+      - name: Run Trivy for HIGH and CRITICAL CVEs and generate report
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: user-manage-ldap:${{ github.run_id }}
-          exit-code: 1
+          exit-code: 0
           ignore-unfixed: true
           vuln-type: os,library
-          severity: CRITICAL
+          severity: HIGH,CRITICAL
           format: sarif
           output: trivy-results.sarif
           skip-setup-trivy: true
+          scanners: vuln
+
+      # This step now prints a table of only CRITICAL vulnerabilities for debugging.
+      - name: Debug - Find CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: user-manage-ldap:${{ github.run_id }}
+          exit-code: 0 # Temporarily set to 0 to prevent failure
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL
+          format: table # Force table output for easy reading in logs
+          skip-setup-trivy: true
+          scanners: vuln
 
       - name: Upload Trivy scan results to Github Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -65,14 +65,14 @@ jobs:
           format: table
           exit-code: 0
 
-      - name: Run Trivy for HIGH and CRITICAL CVEs and report (blocking)
+      - name: Fail build on CRITICAL vulnerabilities (blocking)
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: user-manage-ldap:${{ github.run_id }}
           exit-code: 1
           ignore-unfixed: true
           vuln-type: os,library
-          severity: HIGH,CRITICAL
+          severity: CRITICAL
           format: sarif
           output: trivy-results.sarif
           skip-setup-trivy: true

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -80,18 +80,15 @@ jobs:
           skip-setup-trivy: true
           scanners: vuln
 
-      # This step now prints a table of only CRITICAL vulnerabilities for debugging.
-      - name: Debug - Find CRITICAL vulnerabilities
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: user-manage-ldap:${{ github.run_id }}
-          exit-code: 0 # Temporarily set to 0 to prevent failure
-          ignore-unfixed: true
-          vuln-type: os,library
-          severity: CRITICAL
-          format: table # Force table output for easy reading in logs
-          skip-setup-trivy: true
-          scanners: vuln
+      # This new step directly checks the SARIF file for critical issues.
+      - name: Check for CRITICAL vulnerabilities in SARIF report
+        run: |
+          if grep -q '"level": "critical"' trivy-results.sarif; then
+            echo "CRITICAL vulnerabilities found in trivy-results.sarif. Failing the build."
+            exit 1
+          else
+            echo "No CRITICAL vulnerabilities found. Build can continue."
+          fi
 
       - name: Upload Trivy scan results to Github Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -72,12 +72,10 @@ jobs:
         with:
           image-ref: user-manage-ldap:${{ github.run_id }}
           exit-code: 0
-          ignore-unfixed: true
           vuln-type: os,library
           severity: HIGH,CRITICAL
           format: sarif
           output: trivy-results.sarif
-          skip-setup-trivy: true
           scanners: vuln
 
       # This new step directly checks the SARIF file for critical issues.

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -65,6 +65,7 @@ jobs:
           severity: HIGH,CRITICAL
           format: sarif
           output: trivy-results.sarif
+          skip-setup-trivy: true
 
       - name: Upload Trivy scan results to Github Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Debug Dependency Tree
         run: |
-          docker run --rm --entrypoint mvn user-manage-ldap:${{ github.run_id }} dependency:tree -Dincludes=org.apache.maven:maven-core
+          echo "Searching for maven-core jars inside the container's .m2 repository..."
+          docker run --rm --entrypoint /bin/sh user-manage-ldap:${{ github.run_id }} -c "find /root/.m2 -name '*maven-core*.jar'"
 
       - name: Inspect image
         run: |

--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: user-manage-ldap:${{ github.run_id }}
-          exit-code: 0
+          exit-code: 1
           ignore-unfixed: true
           vuln-type: os,library
           severity: HIGH,CRITICAL

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ USER springuser
 WORKDIR /app
 ARG JAR_FILE=target/*.jar
 COPY --from=package --chown=springuser:spring /app/${JAR_FILE} app.jar
+# Activate the 'docker' profile
+ENV SPRING_PROFILES_ACTIVE=docker
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,14 @@
 ---
 services:
+  user-ldap:
+    image: sundalei/user-manage-ldap:pr-10
+    ports:
+      - "8080:8080"
+    environment:
+      - LDAP_HOST=openldap-server
+    depends_on:
+      - openldap
+
   openldap:
     image: osixia/openldap:1.5.0
     container_name: openldap-server

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
+		<plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <version>4.0.0-M13</version>
+        </plugin>
 	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,33 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<project
+ xmlns="http://maven.apache.org/POM/4.0.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.3</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
 	<artifactId>user-manage-ldap</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>Demo to showcase spring ldap</name>
 	<description>Demo project for Spring Boot</description>
-	<url/>
+	<url />
 	<licenses>
-		<license/>
+		<license />
 	</licenses>
 	<developers>
-		<developer/>
+		<developer />
 	</developers>
 	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
 	</scm>
 	<properties>
 		<java.version>17</java.version>
@@ -66,12 +69,11 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>4.0.0-M13</version>
+			</plugin>
 		</plugins>
-		<plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-site-plugin</artifactId>
-            <version>4.0.0-M13</version>
-        </plugin>
 	</build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>4.0.0-M13</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.maven</groupId>
+						<artifactId>maven-core</artifactId>
+						<version>3.9.6</version> <!-- Force a safe version -->
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -72,14 +72,7 @@
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>4.0.0-M13</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven</groupId>
-						<artifactId>maven-core</artifactId>
-						<version>3.9.6</version> <!-- Force a safe version -->
-					</dependency>
-				</dependencies>
+                <version>4.0.0-M16</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,3 +1,4 @@
+---
 spring:
   ldap:
     urls: ldap://ldap:389

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,4 +1,4 @@
 ---
 spring:
   ldap:
-    urls: ldap://ldap:389
+    urls: ldap://${LDAP_HOST:ldap}:389

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,0 +1,3 @@
+spring:
+  ldap:
+    urls: ldap://ldap:389

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     name: user-management-ldap
 
   ldap:
-    urls: ldap://localhost:389
+    urls: ldap://${LDAP_HOST:localhost}:389
     base: dc=springframework,dc=org
     username: cn=admin,dc=springframework,dc=org
     password: password


### PR DESCRIPTION
- Add security-events write permission for workflow
- Include checkout step before build
- Disable automatic push during test build
- Add trivy scan for HIGH/CRITICAL CVEs with sarif output
- Upload scan results to GitHub Security tab