### PR TITLE
feat: Update Docker build and CI workflow

### DIFF
--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -42,35 +42,26 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: false
-          load: true
-          tags: user-manage-ldap:${{ github.run_id }}
+          load: true # Export to Docker Engine rather than pushing to registry
+          tags: ${{ github.run_id }}
           target: test
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/arm64
 
-      - name: Debug Dependency Tree
-        run: |
-          echo "Resolving plugin dependencies to find the source of the vulnerability..."
-          docker run --rm --entrypoint mvn user-manage-ldap:${{ github.run_id }} dependency:resolve-plugins
-
-      - name: Inspect image
-        run: |
-          docker image inspect user-manage-ldap:${{ github.run_id }}
-
       - name: Run Trivy for all CVEs (non-blocking)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.32.0
         with:
-          image-ref: user-manage-ldap:${{ github.run_id }}
+          image-ref: ${{ github.run_id }}
           format: table
           exit-code: 0
 
       # This step generates the SARIF report with both HIGH and CRITICAL vulnerabilities
       # but does not block the workflow.
       - name: Run Trivy for HIGH and CRITICAL CVEs and generate report
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.32.0
         with:
-          image-ref: user-manage-ldap:${{ github.run_id }}
+          image-ref: ${{ github.run_id }}
           exit-code: 0
           vuln-type: os,library
           severity: HIGH,CRITICAL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.6-eclipse-temurin-17 AS build
+FROM maven:3.9.10-eclipse-temurin-21 AS build
 WORKDIR /app
 COPY pom.xml .
 RUN mvn dependency:go-offline
@@ -18,6 +18,7 @@ ARG JAR_FILE=target/*.jar
 COPY --from=package --chown=springuser:spring /app/${JAR_FILE} app.jar
 # Activate the 'docker' profile
 ENV SPRING_PROFILES_ACTIVE=docker
+ENV LDAP_HOST=ldap
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1


### PR DESCRIPTION
- Bumps the base image in the Dockerfile to use Java 21.
- Adds LDAP_HOST environment variable for easier configuration.
- Updates the GitHub Actions workflow:
  - Pins aquasecurity/trivy-action to version 0.32.0.
  - Simplifies image tagging.
  - Removes unnecessary debug steps.