### PR TITLE
ci(workflows): add ghcr.io login and packages write permission

### DIFF
--- a/.github/workflows/test-and-deploy-image.yaml
+++ b/.github/workflows/test-and-deploy-image.yaml
@@ -13,16 +13,12 @@ permissions:
   contents: read
   pull-requests: write
   security-events: write
+  packages: write
 
 jobs:
   build-image:
     name: Build image
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      pull-requests: write
-      security-events: write
 
     steps:
       - name: Checkout git repo
@@ -39,6 +35,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to ghcr.io registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and export to Docker for Unit Tests
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Add GitHub Container Registry login step and required packages write permission to workflow. This enables pushing images to ghcr.io in addition to Docker Hub.